### PR TITLE
修正しました☆☆☆

### DIFF
--- a/listを回しているときに要素を消すとforが続くエラー/main.cpp
+++ b/listを回しているときに要素を消すとforが続くエラー/main.cpp
@@ -14,20 +14,22 @@ public:
     Dead
   };
 
-protected:
-  std::string name;
-  State state;
-
-public:
   Object() : state(State::Awake) {}
 
-  bool isAwake() { return state == State::Awake ? true : false; }
-  bool isActive() { return state == State::Active ? true : false; }
-  bool isDead() { return state == State::Dead ? true : false; }
+  // ? :　で見なくてもいい。不安なら()で囲う事。
+  bool isAwake() { return state == State::Awake; }
+  bool isActive() { return state == State::Active; }
+  bool isDead() { return state == State::Dead; }
 
   std::string getName() { return name; }
 
   virtual void update() {};
+
+// public -> protected -> publicとアクセス演算子が変わっていたので修正
+protected:
+	std::string name;
+	State state;
+
 };
 
 class Item : public Object {
@@ -46,9 +48,12 @@ int main() {
   std::map<std::string, std::shared_ptr<Object>> map;
   std::list<std::shared_ptr<Object>> list;
 
-  std::shared_ptr<Item> item;
-  item = std::make_shared<Item>();
-  if (item->isActive()) { std::cout << "item init" << std::endl; }
+  std::shared_ptr<Item> item = std::make_shared<Item>();
+
+  if (item->isActive())
+  {
+	  std::cout << "item init" << std::endl;
+  }
 
   map.emplace(item->getName(), item);
   list.emplace_back(item);
@@ -58,20 +63,24 @@ int main() {
     std::cout << it->second->getName() << " in map" << std::endl;
   }
 
-
-  //-------- クソコードはこちら ----------//
+  std::cout << "list size : " << list.size() << std::endl;
+  std::cout << "for each Start !" << std::endl;
   for (auto& it : list) {
     it->update();
-    //list.remove_if([](std::weak_ptr<Object> obj) { return obj.lock()->isDead(); });
   }
-  //------------------------------------//
+
+  std::cout << "for each End !" << std::endl;
+
+  //for each 処理の内部で呼ばない事。
+  list.remove_if([](std::weak_ptr<Object> obj) { return obj.lock()->isDead(); });
+ 
+  std::cout << "list size : " << list.size() << std::endl;
+
 
   {
     auto it = map.find("item");
     map.erase(it);
   }
-
-  list.remove_if([](std::weak_ptr<Object> obj) { return obj.lock()->isDead(); });
 
   if (item->isDead()) { std::cout << "item dead" << std::endl; }
 

--- a/参照で引数を取ったときのエラー/main.cpp
+++ b/参照で引数を取ったときのエラー/main.cpp
@@ -36,7 +36,7 @@ int main(){
   Test01 test01;
   Test02 test02;
 
-  test02.copy(test01.getX()); // err
+  test02.copy(const test01.getX()); // err
 
   // initial value of reference to non_const must be an lvalue
   // const型をもたないリファレンスの初期値は左辺値でなければなりません


### PR DESCRIPTION
# エラーについて
## for文の方
- foreachのループの条件としてコンテナや配列を使っている時に**元データの長さを変えるのはやめよう**。<br>
  私がstd::listやstd::vector、for(auto it : list)を設計した人ではないので100%あっているとは思いませんが、<br>
  コンテナを使っていて、foreachのような使い方をする時のforのループをする条件を見るときに、<br>

```
for (auto& it = list.begin();it != list.end();++it){}
```

みたいな感じに内部で変換する仕様となっているのでは無いですかね？
今回の場合だと、
1. itには**１つ目**の要素の位置を意味するイテレータが入っていた。
2. forの処理中に**listの全長がitより少ない値に(短く)なって**しまった。
3. **it != list.end()の条件に合わない**からまだ**ループをしようとする**[it > list.end()となっている（例え話です。)]
4. **itが１つ次に移動する。**（本当は無い場所を指す）
5. **nullの位置を示すitの処理を行おうとする。**
6. **エラーを吐く。**<br>
って感じですかね？<br>

どっちにしろUpdateやRender等の処理をする部分と削除する部分は分けて記述しましょう。
## 参照渡しの方
- 参照で渡しているので渡す変数は渡された関数等で書き換えられます。
- **安全性の問題**からのエラーではないでしょうか？
